### PR TITLE
Add replay functionality

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ struct Opts {
     cmd: Command,
 }
 
+/// Execute and trace a chosen application on a target device and record
+/// the trace stream to file.
 #[derive(StructOpt, Debug)]
 struct TraceOpts {
     /// Binary to flash and trace.
@@ -44,6 +46,7 @@ struct TraceOpts {
     remove_prev_traces: bool,
 }
 
+/// Replay a previously recorded trace stream for post-mortem analysis.
 #[derive(StructOpt, Debug)]
 struct ReplayOpts {
     #[structopt(long = "list", short = "l")]


### PR DESCRIPTION
See #1. At the moment the file is replayed unto stdout and lacks some checks for erronous trace files. Example:
```
$ cargo rtic-scope replay 5 --bin blinky
"cargo" "build" "--bin" "blinky" "--message-format=json"
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
Replaying /home/tmplt/exjobb/trace-examples/target/rtic-traces/blinky-gfd32d0f-2021-06-21T16:18:34.trace
exceptions:
         SysTick -> ["app", "toggle"]
interrupts:
         18 -> (["app", "external"], "ADC")
software tasks:
         0 -> ["app", "software_task"]
         1 -> ["app", "software_task", "nested"]

timestamp: 2021-06-21 16:18:37.641890166 +02:00
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(1999999), data_relation: Some(Sync), diverged: false }, packets: [] }
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(3999998), data_relation: Some(Sync), diverged: false }, packets: [] }
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(5983559), data_relation: Some(Sync), diverged: false }, packets: [ExceptionTrace { exception: Exception(SysTick), action: Entered }] }
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(5985501), data_relation: Some(Sync), diverged: false }, packets: [ExceptionTrace { exception: Interrupt { irqn: 23 }, action: Entered }] }
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(5988213), data_relation: Some(Sync), diverged: false }, packets: [DataTraceValue { comparator: 1, access_type: Write, value: [0, 0, 0, 0] }] }
TimestampedTracePackets { timestamp: Timestamp { base: None, delta: Some(5999990), data_relation: Some(UnknownAssocEventDelay), diverged: true }, packets: [Overflow, DataTraceValue { comparator: 1, access_type: Write, value: [0, 0, 0, 0] }, Overflow, ExceptionTrace { exception: Exception(SysTick), action: Exited }] }
...
```

This functionality will be handy when the frontend is implemented.

----

Missing is the functionality of replaying into a socket of some kind that should be connected to a front-end. A Dummy frontend should be implemented.