### PR TITLE
test --frontend from PATH, relative, and absolute path

### DIFF
--- a/cargo-rtic-scope/src/main.rs
+++ b/cargo-rtic-scope/src/main.rs
@@ -108,6 +108,7 @@ struct ReplayOptions {
     #[structopt(name = "list", long = "list", short = "l")]
     list: bool,
 
+    /// Relative path to trace file to replay.
     #[structopt(name = "trace-file", long = "trace-file")]
     trace_file: Option<PathBuf>,
 


### PR DESCRIPTION
Before this commit, a frontend was required to be available in PATH.
This works well for an end-user, not so much for development purposes. A
frontend can now be specified via

         --frontend=dummy # for rtic-scope-frontend-dummy in PATH
         --frontend=relative/path/to/dummy
         --frontend/absolute/path/to/dummy

Closes #62.