### PR TITLE
Refactor recovery module, record software task dispatchers

### DIFF
--- a/.ci/expected/out/general.run
+++ b/.ci/expected/out/general.run
@@ -1,8 +1,46 @@
-exceptions:
-        SysTick -> ["app", "systick"]
-interrupts:
-        18 -> (["app", "adc"], "ADC")
-software tasks:
-        0 -> ["app", "foo"]
-        1 -> ["app", "bar"]
-        2 -> ["app", "baz"]
+TraceLookupMaps {
+    software: SoftwareMap {
+        task_dispatchers: {
+            Interrupt {
+                irqn: 22,
+            },
+            Interrupt {
+                irqn: 23,
+            },
+        },
+        comparators: {
+            1: Entered,
+            2: Exited,
+        },
+        map: {
+            0: [
+                "app",
+                "foo",
+            ],
+            1: [
+                "app",
+                "bar",
+            ],
+            2: [
+                "app",
+                "baz",
+            ],
+        },
+    },
+    hardware: HardwareMap(
+        {
+            Exception(
+                SysTick,
+            ): [
+                "app",
+                "systick",
+            ],
+            Interrupt {
+                irqn: 34,
+            }: [
+                "app",
+                "adc",
+            ],
+        },
+    ),
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,6 @@ jobs:
           path: target/${{ matrix.target }}/debug/cargo-rtic-scope
 
   resolve:
-    if: ${{ false }} # disable for now, see <https://github.com/rtic-scope/cargo-rtic-scope/pull/65>
     name: test_output.sh
     runs-on: ubuntu-20.04
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,7 @@ jobs:
           path: target/${{ matrix.target }}/debug/cargo-rtic-scope
 
   resolve:
+    if: ${{ false }} # disable for now, see <https://github.com/rtic-scope/cargo-rtic-scope/pull/65>
     name: test_output.sh
     runs-on: ubuntu-20.04
     needs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "futures",
  "git2",
  "include_dir",
+ "indexmap",
  "itm-decode",
  "libloading",
  "nix 0.21.2",
@@ -743,6 +744,7 @@ checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "cortex-m 0.7.3",
  "crossterm",
  "ctrlc",
  "futures",
@@ -358,11 +359,12 @@ dependencies = [
 [[package]]
 name = "cortex-m"
 version = "0.7.3"
-source = "git+https://github.com/rtic-scope/cortex-m.git?branch=feat/tracing#880b947c44e78fd07d7c231a3c0c82ed3e54b9ef"
+source = "git+https://github.com/rtic-scope/cortex-m.git?branch=feat/host-feats#8470068c820b72e4df3b12dae3d9f7209303cb73"
 dependencies = [
  "bare-metal",
  "bitfield",
  "embedded-hal",
+ "serde",
  "volatile-register",
 ]
 
@@ -1334,8 +1336,8 @@ dependencies = [
 
 [[package]]
 name = "rtic-scope-api"
-version = "0.1.0-alpha.0"
-source = "git+https://github.com/rtic-scope/api.git#22ae2d5bec481e023aec603584f979a7426e092e"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/rtic-scope/api.git#5ba0c7bd85f8a68201d335119e0ab90f61b6685b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1561,7 +1563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da3d56009c8f32e4f208dbea17df72484154d1040a8969b75d8c73eb7b18fe8f"
 dependencies = [
  "bare-metal",
- "cortex-m 0.7.3",
+ "cortex-m 0.6.7",
  "vcell",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "syn",
  "tempfile",
  "thiserror",
+ "vectorize",
 ]
 
 [[package]]
@@ -1563,7 +1564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da3d56009c8f32e4f208dbea17df72484154d1040a8969b75d8c73eb7b18fe8f"
 dependencies = [
  "bare-metal",
- "cortex-m 0.6.7",
+ "cortex-m 0.7.3",
  "vcell",
 ]
 
@@ -1790,6 +1791,15 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vectorize"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e3bbfdfdcc4ea60ce183b1b45c936aacd69fe097ebf137984a32faf80e365b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["cargo-rtic-scope", "cortex-m-rtic-trace"]
 
 [patch.crates-io]
 include_dir = { version = "0.6.3-alpha.0", git = "https://github.com/tmplt/include_dir.git", branch = "feat/extract-overwrite" }
-cortex-m = { git = "https://github.com/rtic-scope/cortex-m.git", branch = "feat/tracing" }
+cortex-m = { git = "https://github.com/rtic-scope/cortex-m.git", branch = "feat/host-feats" }

--- a/cargo-rtic-scope/Cargo.toml
+++ b/cargo-rtic-scope/Cargo.toml
@@ -23,6 +23,7 @@ libloading = "0.7"
 rtic-syntax = "=0.5.0-rc.1"
 serde = "1"
 serde_json = "1"
+vectorize = "0.2.0"
 rtic-scope-api = { version = "0.1.0-alpha.1", git = "https://github.com/rtic-scope/api.git" }
 tempfile = "3"
 ctrlc = "3"

--- a/cargo-rtic-scope/Cargo.toml
+++ b/cargo-rtic-scope/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = "1"
 colored = "2"
 crossterm = "0.20"
 futures = "0.3"
+cortex-m = { version = "0.7", default-features = false, features = ["serde", "std-map"] }
 
 [dependencies.probe-rs]
 version = "0.11"

--- a/cargo-rtic-scope/Cargo.toml
+++ b/cargo-rtic-scope/Cargo.toml
@@ -32,6 +32,7 @@ colored = "2"
 crossterm = "0.20"
 futures = "0.3"
 cortex-m = { version = "0.7", default-features = false, features = ["serde", "std-map"] }
+indexmap = { version = "1.7", features = [ "serde-1" ] }
 
 [dependencies.probe-rs]
 version = "0.11"

--- a/cargo-rtic-scope/src/main.rs
+++ b/cargo-rtic-scope/src/main.rs
@@ -240,6 +240,7 @@ async fn main_try() -> Result<(), RTICScopeError> {
     // Build RTIC application to be traced, and create a wrapper around
     // cargo, reusing the target directory of the application.
     log::status("Building", "RTIC target application...".to_string());
+    #[allow(clippy::needless_question_mark)]
     let cart = async {
         Ok(CargoWrapper::new(
             &env::current_dir().map_err(CargoError::CurrentDirError)?,

--- a/cargo-rtic-scope/src/manifest.rs
+++ b/cargo-rtic-scope/src/manifest.rs
@@ -37,30 +37,25 @@ impl Default for ManifestPropertiesIntermediate {
 
 impl ManifestPropertiesIntermediate {
     pub fn complete_with(&mut self, other: Self) {
-        if self.pac_name.is_none() {
-            self.pac_name = other.pac_name;
+        macro_rules! complete {
+            ($($f:ident),+) => {{
+                $(
+                    if self.$f.is_none() {
+                        self.$f = other.$f;
+                    }
+                )+
+            }}
         }
-        if self.pac_version.is_none() {
-            self.pac_version = other.pac_version;
-        }
-        if self.interrupt_path.is_none() {
-            self.interrupt_path = other.interrupt_path;
-        }
-        if self.pac_features.is_none() {
-            self.pac_features = other.pac_features;
-        }
-        if self.tpiu_freq.is_none() {
-            self.tpiu_freq = other.tpiu_freq;
-        }
-        if self.tpiu_baud.is_none() {
-            self.tpiu_baud = other.tpiu_baud;
-        }
-        if self.dwt_enter_id.is_none() {
-            self.dwt_enter_id = other.dwt_enter_id;
-        }
-        if self.dwt_exit_id.is_none() {
-            self.dwt_exit_id = other.dwt_exit_id;
-        }
+        complete!(
+            pac_name,
+            pac_version,
+            pac_features,
+            interrupt_path,
+            tpiu_freq,
+            tpiu_baud,
+            dwt_enter_id,
+            dwt_exit_id
+        );
     }
 }
 
@@ -100,8 +95,8 @@ impl diag::DiagnosableError for ManifestMetadataError {
             Self::MissingName => vec!["Add `pac_name = \"<your PAC name>\"` to [package.metadata.rtic-scope] in Cargo.toml or specify --pac-name".into()],
             Self::MissingVersion => vec!["Add `pac_version = \"your PAC version\"` to [package.metadata.rtic-scope] in Cargo.toml or specify --pac-version".into()],
             Self::MissingInterruptPath => vec!["Add `interrupt_path = \"path to your PAC's Interrupt enum\"` to [package.metadata.rtic-scope] in Cargo.toml or specify --pac-interrupt-path".into()],
-            Self::MissingFreq => vec!["Add `tpiu_freq = \"your TPIU frequency\" to [package.metadata.rtic-scope] in Cargo.toml or specify --tpiu-freq`".into()],
-            Self::MissingBaud => vec!["Add `tpiu_baud = \"your TPIU baud rate\" to [package.metadata.rtic-scope] in Cargo.toml or specify --tpiu-baud`".into()],
+            Self::MissingFreq => vec!["Add `tpiu_freq = \"your TPIU frequency\"` to [package.metadata.rtic-scope] in Cargo.toml or specify --tpiu-freq".into()],
+            Self::MissingBaud => vec!["Add `tpiu_baud = \"your TPIU baud rate\"` to [package.metadata.rtic-scope] in Cargo.toml or specify --tpiu-baud".into()],
             Self::MissingDWTUnit => vec!["Add `dwt_enter_id = \"your enter DWT unit ID\"` and `dwt_exit_id = \"your exit DWT unit ID\"` to [package.metadata.rtic-scope] in Cargo.toml".into()],
             _ => vec![],
         }
@@ -151,29 +146,24 @@ impl ManifestProperties {
             _ => ManifestPropertiesIntermediate::default(),
         };
 
-        let override_with_opts = |int: &mut ManifestPropertiesIntermediate,
-                                  opts: &ManifestOptions| {
-            if let Some(pac) = &opts.pac_name {
-                int.pac_name = Some(pac.to_owned());
-            }
-            if let Some(pac_version) = &opts.pac_version {
-                int.pac_version = Some(pac_version.to_owned());
-            }
-            if let Some(intp) = &opts.interrupt_path {
-                int.interrupt_path = Some(intp.to_owned());
-            }
-            if let Some(feats) = &opts.pac_features {
-                int.pac_features = Some(feats.to_owned());
-            }
-            if let Some(freq) = &opts.tpiu_freq {
-                int.tpiu_freq = Some(freq.to_owned());
-            }
-            if let Some(baud) = &opts.tpiu_baud {
-                int.tpiu_baud = Some(baud.to_owned());
-            }
-        };
         if let Some(opts) = opts {
-            override_with_opts(&mut int, opts);
+            macro_rules! maybe_override {
+                ($($f:ident),+) => {{
+                    $(
+                        if let Some($f) = &opts.$f {
+                            int.$f = Some($f.to_owned());
+                        }
+                    )+
+                }}
+            }
+            maybe_override!(
+                pac_name,
+                pac_version,
+                pac_features,
+                interrupt_path,
+                tpiu_freq,
+                tpiu_baud
+            );
         }
 
         int.try_into()

--- a/cargo-rtic-scope/src/manifest.rs
+++ b/cargo-rtic-scope/src/manifest.rs
@@ -118,7 +118,7 @@ impl TryInto<ManifestProperties> for ManifestPropertiesIntermediate {
             interrupt_path: self
                 .interrupt_path
                 .ok_or(Self::Error::MissingInterruptPath)?,
-            pac_features: self.pac_features.unwrap_or([].to_vec()),
+            pac_features: self.pac_features.unwrap_or_else(|| [].to_vec()),
             tpiu_freq: self.tpiu_freq.ok_or(Self::Error::MissingFreq)?,
             tpiu_baud: self.tpiu_baud.ok_or(Self::Error::MissingBaud)?,
             dwt_enter_id: self.dwt_enter_id.ok_or(Self::Error::MissingDWTUnit)?,

--- a/cargo-rtic-scope/src/recovery.rs
+++ b/cargo-rtic-scope/src/recovery.rs
@@ -2,40 +2,31 @@ use crate::build::{self, CargoWrapper};
 use crate::diag;
 use crate::manifest::ManifestProperties;
 
-use std::collections::BTreeMap;
-use std::fmt;
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 
 use cargo_metadata::Artifact;
 use chrono::Local;
 use include_dir::{dir::ExtractMode, include_dir};
-use itm_decode::{ExceptionAction, MemoryAccessType, TimestampedTracePackets, TracePacket};
+use itm_decode::{
+    cortex_m::VectActive, ExceptionAction, MemoryAccessType, TimestampedTracePackets, TracePacket,
+};
 
-use proc_macro2::{Ident, TokenStream, TokenTree};
+use proc_macro2::{TokenStream, TokenTree};
 use quote::{format_ident, quote};
 use rtic_scope_api::{self as api, EventChunk, EventType, TaskAction};
-
 use serde::{Deserialize, Serialize};
-
 use thiserror::Error;
-
-type HwExceptionNumber = u16;
-type SwExceptionNumber = usize;
-type ExceptionIdent = String;
-type TaskIdent = [String; 2];
-type ExternalHwAssocs = BTreeMap<HwExceptionNumber, (TaskIdent, ExceptionIdent)>;
-type InternalHwAssocs = BTreeMap<ExceptionIdent, TaskIdent>;
-type SwAssocs = BTreeMap<SwExceptionNumber, Vec<String>>;
 
 #[derive(Debug, Error)]
 pub enum RecoveryError {
-    #[error("The IRQ ({0:?}) -> RTIC task mapping does not exist")]
-    MissingHWLabelExceptionMap(itm_decode::cortex_m::Exception),
-    #[error("The IRQ ({0}) -> RTIC task mapping does not exist")]
-    MissingHWExceptionMap(HwExceptionNumber),
-    #[error("The DataTraceValue ({0:?}) -> RTIC task mapping does not exist")]
-    MissingSWMap(Vec<u8>),
+    #[error("The DataTraceValue {0:?} does not map to any software task")]
+    MissingSoftwareMapping(usize),
+    #[error("The DataTraceValue {0:#?} is not a valid payload")]
+    InvalidSoftwareValue(Vec<u8>),
+    #[error("The IRQ {0:?} does not map to any hardware task or software task dispatcher")]
+    MissingHardwareMapping(VectActive),
     #[error("Failed to read artifact source file: {0}")]
     SourceRead(#[source] std::io::Error),
     #[error("Failed to tokenize artifact source file: {0}")]
@@ -61,234 +52,58 @@ impl diag::DiagnosableError for RecoveryError {
                 "RTIC Scope expects an RTIC application declaration on the form `#[app(...)] mod app { ... }` where the first `...` is the application arguments.".to_string(),
                 "Change #[rtic::app(...)] to #[app(...)] via `use rtic::app;`.".to_string(),
             ],
+            RecoveryError::InvalidSoftwareValue(_) => vec![
+                "Invalid DataTraceValue payloads are those of zero length or with non-zero subsequent bytes (only the first byte may be non-zero).".to_string(),
+                "RTIC Scope supports up to 255 software tasks at the present.".to_string(),
+            ],
             _ => vec![],
         }
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Metadata {
-    program_name: String,
-    maps: TaskResolveMaps,
-    manip: ManifestProperties,
-    timestamp: chrono::DateTime<Local>,
-    freq: u32,
-    comment: Option<String>,
+/// Lookup maps for hardware and software tasks (along with software
+/// task dispatchers and relevant DWT units). Keys are ...
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct TraceLookupMaps {
+    software: SoftwareMap,
+    hardware: HardwareMap,
 }
 
-impl Metadata {
-    pub fn new(
-        program_name: String,
-        maps: TaskResolveMaps,
-        manip: ManifestProperties,
-        timestamp: chrono::DateTime<Local>,
-        freq: u32,
-        comment: Option<String>,
-    ) -> Self {
-        Self {
-            program_name,
-            maps,
-            manip,
-            timestamp,
-            freq,
-            comment,
-        }
-    }
-
-    pub fn hardware_tasks(&self) -> usize {
-        self.maps.exceptions.len() + self.maps.interrupts.len()
-    }
-
-    pub fn software_tasks(&self) -> usize {
-        self.maps.sw_assocs.len()
-    }
-
-    pub fn comment(&self) -> String {
-        self.comment.clone().unwrap_or("".to_string())
-    }
-
-    pub fn program_name(&self) -> String {
-        self.program_name.clone()
-    }
-
-    pub fn build_event_chunk(&self, packets: TimestampedTracePackets) -> EventChunk {
-        let timestamp = {
-            let itm_decode::Timestamp {
-                base,
-                delta,
-                data_relation,
-                diverged,
-            } = packets.timestamp;
-            let seconds_since = (base.unwrap_or(0) + delta.expect("timestamp delta is None"))
-                as f64
-                / self.freq as f64;
-            let since = chrono::Duration::nanoseconds((seconds_since * 1e9).round() as i64);
-
-            api::Timestamp {
-                ts: self.timestamp + since,
-                data_relation,
-                diverged,
-            }
-        };
-
-        let resolve_hw_task = |&excpt| -> Result<String, RecoveryError> {
-            use itm_decode::cortex_m::VectActive;
-
-            match excpt {
-                VectActive::ThreadMode => Ok("ThreadMode".to_string()),
-                VectActive::Exception(e) => Ok(self
-                    .maps
-                    .exceptions
-                    .get(&format!("{:?}", e))
-                    .ok_or(RecoveryError::MissingHWLabelExceptionMap(e))?
-                    .join("::")),
-                VectActive::Interrupt { irqn } => {
-                    let (fun, _bind) = self
-                        .maps
-                        .interrupts
-                        .get(&irqn.into())
-                        .ok_or(RecoveryError::MissingHWExceptionMap(irqn.into()))?;
-                    Ok(fun.join("::"))
-                }
-            }
-        };
-
-        let resolve_sw_task = |value: Vec<u8>| -> Result<String, RecoveryError> {
-            if value.iter().filter(|&b| *b > 0).count() > 1 || value.is_empty() {
-                return Err(RecoveryError::MissingSWMap(value));
-            }
-            self.maps
-                .sw_assocs
-                .get(&(value[0] as usize))
-                .map(|v| v.join("::"))
-                .ok_or(RecoveryError::MissingSWMap(value))
-        };
-
-        // convert itm_decode::TracePacket -> api::EventType
-        let mut events = vec![];
-        for packet in packets.packets.iter() {
-            match packet {
-                TracePacket::Sync => (), // noop: only used for byte alignment; contains no data
-                TracePacket::Overflow => {
-                    events.push(EventType::Overflow);
-                }
-                TracePacket::ExceptionTrace { exception, action } => events.push(EventType::Task {
-                    name: match resolve_hw_task(exception) {
-                        Ok(name) => name,
-                        Err(e) => {
-                            events.push(EventType::Unmappable(packet.clone(), e.to_string()));
-                            continue;
-                        }
-                    },
-                    action: match action {
-                        ExceptionAction::Entered => TaskAction::Entered,
-                        ExceptionAction::Exited => TaskAction::Exited,
-                        ExceptionAction::Returned => TaskAction::Returned,
-                    },
-                }),
-                TracePacket::DataTraceValue {
-                    comparator,
-                    access_type,
-                    value,
-                } if *access_type == MemoryAccessType::Write => events.push(EventType::Task {
-                    action: match *comparator as usize {
-                        c if c == self.manip.dwt_enter_id => TaskAction::Entered,
-                        c if c == self.manip.dwt_exit_id => TaskAction::Exited,
-                        _ => {
-                            events.push(EventType::Unknown(packet.clone()));
-                            continue;
-                        }
-                    },
-                    name: match resolve_sw_task(value.clone()) {
-                        Ok(name) => name,
-                        Err(e) => {
-                            events.push(EventType::Unmappable(packet.clone(), e.to_string()));
-                            continue;
-                        }
-                    },
-                }),
-                _ => events.push(EventType::Unknown(packet.clone())),
-            }
-        }
-
-        // map malformed packets
-        events.append(
-            &mut packets
-                .malformed_packets
-                .iter()
-                .map(|m| EventType::Invalid(m.to_owned()))
-                .collect(),
-        );
-
-        EventChunk { timestamp, events }
-    }
-}
-
-impl fmt::Display for Metadata {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "{}", self.maps)?;
-        writeln!(f, "reset timestamp: {}", self.timestamp)?;
-        writeln!(f, "trace clock frequency: {} Hz", self.freq)?;
-
-        Ok(())
-    }
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub struct TaskResolveMaps {
-    pub exceptions: InternalHwAssocs,
-    pub interrupts: ExternalHwAssocs,
-    pub sw_assocs: SwAssocs,
-}
-
-impl fmt::Display for TaskResolveMaps {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Here C++ reigns superior with its generic lambdas.
-        macro_rules! display_map {
-            ($h:expr, $m:expr) => {{
-                writeln!(f, "{}:", $h)?;
-                for (k, v) in $m.iter() {
-                    writeln!(f, "        {} -> {:?}", k, v)?;
-                }
-
-                Ok(())
-            }};
-        }
-
-        display_map!("exceptions", self.exceptions)?;
-        display_map!("interrupts", self.interrupts)?;
-        display_map!("software tasks", self.sw_assocs)
-    }
-}
-
-pub struct TaskResolver<'a> {
-    cargo: &'a CargoWrapper,
-    app: TokenStream,
-    app_args: TokenStream,
-    pacp: ManifestProperties,
-}
-
-impl<'a> TaskResolver<'a> {
-    pub fn new(
+impl TraceLookupMaps {
+    pub fn from(
+        cargo: &CargoWrapper,
         artifact: &Artifact,
-        cargo: &'a CargoWrapper,
-        pacp: ManifestProperties,
+        manip: &ManifestProperties,
     ) -> Result<Self, RecoveryError> {
-        // parse the RTIC app from the source file
-        let src =
-            fs::read_to_string(&artifact.target.src_path).map_err(RecoveryError::SourceRead)?;
-        let mut rtic_app = syn::parse_str::<TokenStream>(&src)
-            .map_err(RecoveryError::TokenizeFail)?
-            .into_iter()
-            .skip_while(|token| {
-                if let TokenTree::Group(g) = token {
-                    if let Some(c) = g.stream().into_iter().next() {
-                        return c.to_string().as_str() != "app";
-                    }
+        // Parse the RTIC app from the source code and analyze it via
+        // rtic-syntax.
+        let src = syn::parse_str::<TokenStream>(
+            &fs::read_to_string(artifact.target.src_path.as_std_path())
+                .map_err(RecoveryError::SourceRead)?,
+        )
+        .map_err(RecoveryError::TokenizeFail)?;
+        let (app, ast) = Self::parse_rtic_app(src)?;
+
+        Ok(Self {
+            software: SoftwareMap::from(&app, ast, manip, cargo)?,
+            hardware: HardwareMap::from(&app, cargo, manip)?,
+        })
+    }
+
+    fn parse_rtic_app(
+        src: TokenStream,
+    ) -> Result<(rtic_syntax::P<rtic_syntax::ast::App>, TokenStream), RecoveryError> {
+        // iterate over the tokenstream until we find #[app(...)] mod app { ... }
+        let mut rtic_app = src.into_iter().skip_while(|token| {
+            if let TokenTree::Group(g) = token {
+                if let Some(c) = g.stream().into_iter().next() {
+                    return c.to_string().as_str() != "app";
                 }
-                true
-            });
-        let app_args = {
+            }
+            true
+        });
+        // extract the arguments in #[app(...)]
+        let arguments = {
             let mut args: Option<TokenStream> = None;
             if let Some(TokenTree::Group(g)) = rtic_app.next() {
                 if let Some(TokenTree::Group(g)) = g.stream().into_iter().nth(1) {
@@ -297,31 +112,105 @@ impl<'a> TaskResolver<'a> {
             }
             args.ok_or(RecoveryError::RTICArgumentsMissing)?
         };
-        let app = rtic_app.collect::<TokenStream>();
+        let ast = rtic_app.collect::<TokenStream>();
 
-        Ok(TaskResolver {
+        // parse the found tokenstreams
+        let (app, _analysis) = {
+            let mut settings = rtic_syntax::Settings::default();
+            settings.parse_binds = true;
+            rtic_syntax::parse2(arguments, ast.clone(), settings)
+                .map_err(RecoveryError::RTICParseFail)?
+        };
+        Ok((app, ast))
+    }
+
+    pub fn resolve_hardware_task(
+        &self,
+        veca: &VectActive,
+    ) -> Result<Option<String>, RecoveryError> {
+        if self.software.task_dispatchers.contains(veca) {
+            return Ok(None);
+        }
+
+        Ok(Some(
+            self.hardware
+                .0
+                .get(&veca)
+                .ok_or(RecoveryError::MissingHardwareMapping(veca.to_owned()))?
+                .join("::"),
+        ))
+    }
+
+    pub fn resolve_software_task(
+        &self,
+        comp: &u8,
+        value: &Vec<u8>,
+    ) -> Result<Option<EventType>, RecoveryError> {
+        if let Some(action) = self.software.comparators.get(&(*comp as usize)) {
+            if value.iter().filter(|&b| *b > 0).count() > 1 || value.is_empty() {
+                return Err(RecoveryError::InvalidSoftwareValue(value.to_owned()));
+            }
+            let value = value[0] as usize;
+
+            let name = self
+                .software
+                .map
+                .get(&value)
+                .ok_or(RecoveryError::MissingSoftwareMapping(value))?
+                .join("::");
+
+            return Ok(Some(EventType::Task {
+                name,
+                action: action.to_owned(),
+            }));
+        } else {
+            return Ok(None);
+        }
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+struct SoftwareMap {
+    pub task_dispatchers: HashSet<VectActive>,
+    pub comparators: BTreeMap<usize, TaskAction>,
+    pub map: BTreeMap<usize, Vec<String>>,
+}
+impl SoftwareMap {
+    pub fn from(
+        app: &rtic_syntax::ast::App,
+        ast: TokenStream,
+        manip: &ManifestProperties,
+        cargo: &CargoWrapper,
+    ) -> Result<Self, RecoveryError> {
+        let actions = [
+            (manip.dwt_enter_id, TaskAction::Entered),
+            (manip.dwt_exit_id, TaskAction::Exited),
+        ];
+        let map = Self::parse_ast(ast);
+
+        // Extract all dispatcher interrupt idents from #[app(..,
+        // dispatchers = [..])] and resolve the associated VectActive.
+        let task_dispatchers: HashSet<VectActive> = resolve_int_nrs(
             cargo,
-            app,
-            app_args,
-            pacp,
+            manip,
+            app.args
+                .extern_interrupts
+                .iter()
+                .map(|(ident, _ext_int_attrs)| ident.to_string())
+                .collect(),
+        )?
+        .values()
+        .cloned()
+        .collect();
+
+        Ok(Self {
+            task_dispatchers,
+            comparators: actions.into(),
+            map,
         })
     }
 
-    pub fn resolve(&self) -> Result<TaskResolveMaps, RecoveryError> {
-        let (exceptions, interrupts) = self.hardware_tasks()?;
-        let sw_assocs = self.software_tasks();
-
-        Ok(TaskResolveMaps {
-            exceptions,
-            interrupts,
-            sw_assocs,
-        })
-    }
-
-    /// Parses an RTIC `mod app { ... }` declaration and associates the full
-    /// path of the functions that are decorated with the `#[trace]`-macro
-    /// with it's assigned task ID.
-    fn software_tasks(&self) -> SwAssocs {
+    fn parse_ast(app: TokenStream) -> BTreeMap<usize, Vec<String>> {
         struct TaskIDGenerator(usize);
         impl TaskIDGenerator {
             pub fn new() -> Self {
@@ -337,16 +226,15 @@ impl<'a> TaskResolver<'a> {
             }
         }
 
-        // NOTE(unwrap) the whole source file is parsed in [TaskResolver::new]
-        let app = syn::parse2::<syn::Item>(self.app.clone()).unwrap();
+        let app = syn::parse2::<syn::Item>(app).unwrap();
         let mut ctx: Vec<syn::Ident> = vec![];
-        let mut assocs = SwAssocs::new();
+        let mut assocs = BTreeMap::<usize, Vec<String>>::new();
         let mut id_gen = TaskIDGenerator::new();
 
         fn traverse_item(
             item: &syn::Item,
             ctx: &mut Vec<syn::Ident>,
-            assocs: &mut SwAssocs,
+            assocs: &mut BTreeMap<usize, Vec<String>>,
             id_gen: &mut TaskIDGenerator,
         ) {
             match item {
@@ -409,17 +297,18 @@ impl<'a> TaskResolver<'a> {
 
         assocs
     }
+}
 
-    /// Parses an RTIC `#[app(device = ...)] mod app { ... }` declaration
-    /// and associates the full path of hardware task functions to their
-    /// exception numbers as reported by the target.
-    fn hardware_tasks(&self) -> Result<(InternalHwAssocs, ExternalHwAssocs), RecoveryError> {
-        let (app, _analysis) = {
-            let mut settings = rtic_syntax::Settings::default();
-            settings.parse_binds = true;
-            rtic_syntax::parse2(self.app_args.clone(), self.app.clone(), settings)
-                .map_err(RecoveryError::RTICParseFail)?
-        };
+#[derive(Clone, Serialize, Deserialize, Debug)]
+struct HardwareMap(HashMap<VectActive, Vec<String>>);
+impl HardwareMap {
+    pub fn from(
+        app: &rtic_syntax::ast::App,
+        cargo: &CargoWrapper,
+        manip: &ManifestProperties,
+    ) -> Result<Self, RecoveryError> {
+        // XXX processor core exceptions (internal interrupts)
+        // XXX device-specific exceptions (external interrupts)
 
         // Find the bound exceptions from the #[task(bound = ...)]
         // arguments. Further, partition internal and external
@@ -430,150 +319,308 @@ impl<'a> TaskResolver<'a> {
         // need to resolve the number we receive over ITM back to the
         // interrupt name. For internal interrupts, the name of the
         // exception is received over ITM.
-        let known_exceptions = [
-            "Reset",
-            "NMI",
-            "HardFault",
-            "MemManage",
-            "BusFault",
-            "UsageFault",
-            "SVCall",
-            "DebugMonitor",
-            "PendSV",
-            "SysTick",
-        ];
-        let (int_binds, ext_binds): (Vec<Ident>, Vec<Ident>) = app
-            .hardware_tasks
-            .iter()
-            .map(|(_name, hwt)| hwt.args.binds.clone())
-            .partition(|bind| known_exceptions.iter().any(|&int| *bind == int));
-        let binds = ext_binds.clone();
 
-        // Resolve exception numbers from bound idents
-        let excpt_nrs = if ext_binds.is_empty() {
-            BTreeMap::<Ident, HwExceptionNumber>::new()
-        } else {
-            self.resolve_int_nrs(&binds)?
-        };
-
-        let int_assocs: InternalHwAssocs = app
-            .hardware_tasks
-            .iter()
-            .filter_map(|(name, hwt)| {
-                let bind = &hwt.args.binds;
-                if int_binds.iter().any(|b| b == bind) {
-                    Some((bind.to_string(), ["app".to_string(), name.to_string()]))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        let ext_assocs: ExternalHwAssocs = app
-            .hardware_tasks
-            .iter()
-            .filter_map(|(name, hwt)| {
-                let bind = &hwt.args.binds;
-                excpt_nrs.get(bind).map(|int| {
-                    (
-                        *int,
-                        (["app".to_string(), name.to_string()], bind.to_string()),
-                    )
-                })
-            })
-            .collect();
-
-        Ok((int_assocs, ext_assocs))
-    }
-
-    fn resolve_int_nrs(
-        &self,
-        binds: &[Ident],
-    ) -> Result<BTreeMap<Ident, HwExceptionNumber>, RecoveryError> {
-        const ADHOC_FUNC_PREFIX: &str = "rtic_scope_func_";
-
-        // Extract adhoc source to a temporary directory and apply adhoc
-        // modifications.
-        let target_dir = self.cargo.target_dir().join("cargo-rtic-trace-libadhoc");
-        include_dir!("assets/libadhoc")
-            .extract(&target_dir, ExtractMode::Overwrite)
-            .map_err(RecoveryError::LibExtractFail)?;
-        // NOTE See <https://github.com/rust-lang/cargo/issues/9643>
-        fs::rename(
-            target_dir.join("not-Cargo.toml"),
-            target_dir.join("Cargo.toml"),
+        use cortex_m::peripheral::scb::Exception;
+        macro_rules! resolve_core_interrupts {
+            ($($excpt:ident),+) => {{
+                [$({
+                    let exception = Exception::$excpt;
+                    (format!("{:?}", exception), exception)
+                },)+]
+            }}
+        }
+        let internal_ints: HashMap<String, Exception> = resolve_core_interrupts!(
+            NonMaskableInt,
+            HardFault,
+            MemoryManagement,
+            BusFault,
+            UsageFault,
+            SecureFault,
+            SVCall,
+            DebugMonitor,
+            PendSV,
+            SysTick
         )
+        .into();
+
+        type TaskBindMaps = HashMap<String, String>;
+        let (known_maps, unknown_maps): (TaskBindMaps, TaskBindMaps) = app
+            .hardware_tasks
+            .iter()
+            // Find (interrupt name, task name) associations.
+            .map(|(task_name, hwt)| (hwt.args.binds.to_string(), task_name.to_string()))
+            // Separate core interrupts from device-specific interrupts
+            .partition(|(bind, _)| internal_ints.contains_key(bind));
+        let mut known_maps = known_maps
+            .iter()
+            .map(|(bind, task_name)| {
+                (
+                    VectActive::Exception(*internal_ints.get(bind).unwrap()),
+                    vec!["app".to_string(), task_name.to_owned()],
+                )
+            })
+            .collect();
+
+        if unknown_maps.is_empty() {
+            return Ok(Self(known_maps));
+        }
+
+        // Resolve unknown maps by help of a cdylib; extend the known
+        // map collection.
+        let resolved_maps: HashMap<VectActive, Vec<String>> = resolve_int_nrs(
+            cargo,
+            manip,
+            unknown_maps.iter().map(|(k, _v)| k.to_owned()).collect(),
+        )?
+        .iter()
+        .map(|(bind, irqn)| {
+            (
+                irqn.to_owned(),
+                vec![
+                    "app".to_string(),
+                    unknown_maps.get(bind).unwrap().to_owned(),
+                ],
+            )
+        })
+        .collect();
+        known_maps.extend(resolved_maps);
+
+        Ok(Self(known_maps))
+    }
+}
+
+fn resolve_int_nrs<'a>(
+    cargo: &CargoWrapper,
+    pacp: &ManifestProperties,
+    binds: Vec<String>,
+) -> Result<BTreeMap<String, VectActive>, RecoveryError> {
+    const ADHOC_FUNC_PREFIX: &str = "rtic_scope_func_";
+
+    // Extract adhoc source to a temporary directory and apply adhoc
+    // modifications.
+    let target_dir = cargo.target_dir().join("cargo-rtic-trace-libadhoc");
+    include_dir!("assets/libadhoc")
+        .extract(&target_dir, ExtractMode::Overwrite)
         .map_err(RecoveryError::LibExtractFail)?;
-        // Add required crate (and optional feature) as dependency
-        {
-            let mut manifest = fs::OpenOptions::new()
-                .append(true)
-                .open(target_dir.join("Cargo.toml"))
-                .map_err(RecoveryError::LibExtractFail)?;
-            let dep = format!(
-                "\n{} = {{ version = \"{}\", features = [{}]}}\n",
-                self.pacp.pac_name,
-                self.pacp.pac_version,
-                self.pacp
-                    .pac_features
-                    .iter()
-                    .map(|f| format!("\"{}\"", f))
-                    .collect::<Vec<String>>()
-                    .join(","),
+    // NOTE See <https://github.com/rust-lang/cargo/issues/9643>
+    fs::rename(
+        target_dir.join("not-Cargo.toml"),
+        target_dir.join("Cargo.toml"),
+    )
+    .map_err(RecoveryError::LibExtractFail)?;
+    // Add required crate (and optional feature) as dependency
+    {
+        let mut manifest = fs::OpenOptions::new()
+            .append(true)
+            .open(target_dir.join("Cargo.toml"))
+            .map_err(RecoveryError::LibExtractFail)?;
+        let dep = format!(
+            "\n{} = {{ version = \"{}\", features = [{}]}}\n",
+            pacp.pac_name,
+            pacp.pac_version,
+            pacp.pac_features
+                .iter()
+                .map(|f| format!("\"{}\"", f))
+                .collect::<Vec<String>>()
+                .join(","),
+        );
+        manifest
+            .write_all(dep.as_bytes())
+            .map_err(RecoveryError::LibExtractFail)?;
+    }
+    // Prepare lib.rs
+    {
+        // Import PAC::Interrupt
+        let mut src = fs::OpenOptions::new()
+            .append(true)
+            .open(target_dir.join("src/lib.rs"))
+            .map_err(RecoveryError::LibExtractFail)?;
+        let import = str::parse::<TokenStream>(&pacp.interrupt_path)
+            .expect("Failed to tokenize pacp.interrupt_path");
+        let import = quote!(use #import;);
+        src.write_all(format!("\n{}\n", import).as_bytes())
+            .map_err(RecoveryError::LibExtractFail)?;
+
+        // Generate the functions that must be exported
+        for bind in &binds {
+            let fun = format_ident!("{}{}", ADHOC_FUNC_PREFIX, bind);
+            let int_ident = format_ident!("{}", bind);
+            let fun = quote!(
+                #[no_mangle]
+                pub extern fn #fun() -> u16 {
+                    Interrupt::#int_ident.number()
+                }
             );
-            manifest
-                .write_all(dep.as_bytes())
+            src.write_all(format!("\n{}\n", fun).as_bytes())
                 .map_err(RecoveryError::LibExtractFail)?;
         }
-        // Prepare lib.rs
-        {
-            // Import PAC::Interrupt
-            let mut src = fs::OpenOptions::new()
-                .append(true)
-                .open(target_dir.join("src/lib.rs"))
-                .map_err(RecoveryError::LibExtractFail)?;
-            let import = str::parse::<TokenStream>(&self.pacp.interrupt_path)
-                .expect("Failed to tokenize pacp.interrupt_path");
-            let import = quote!(use #import;);
-            src.write_all(format!("\n{}\n", import).as_bytes())
-                .map_err(RecoveryError::LibExtractFail)?;
+    }
 
-            // Generate the functions that must be exported
-            for bind in binds {
-                let fun = format_ident!("{}{}", ADHOC_FUNC_PREFIX, bind);
-                let int_ident = format_ident!("{}", bind);
-                let fun = quote!(
-                    #[no_mangle]
-                    pub extern fn #fun() -> u16 {
-                        Interrupt::#int_ident.number()
-                    }
-                );
-                src.write_all(format!("\n{}\n", fun).as_bytes())
-                    .map_err(RecoveryError::LibExtractFail)?;
+    // Build the adhoc library, load it, and resolve all exception idents
+    let artifact = cargo.build(
+        &target_dir,
+        // Host target triple need not be specified when CARGO is set.
+        None,
+        "cdylib",
+    )?;
+    let lib = unsafe {
+        libloading::Library::new(artifact.filenames.first().unwrap())
+            .map_err(RecoveryError::LibLoadFail)?
+    };
+    let binds: Result<Vec<(String, VectActive)>, RecoveryError> = binds
+        .iter()
+        .map(|b| {
+            let func: libloading::Symbol<extern "C" fn() -> u16> = unsafe {
+                lib.get(format!("{}{}", ADHOC_FUNC_PREFIX, b).as_bytes())
+                    .map_err(RecoveryError::LibLookupFail)?
+            };
+
+            // Convert the IRQn to a VectActive.
+            //
+            // The offset denotes at what offset from the start of the
+            // interrupt vector external (device-specific) interrupts
+            // are enumerated. cortex_m::interrupt::InterruptNumber
+            // (used above) enumerates starting at this offset so we
+            // must compensate. See also B1.5.2 in the ARMv7-M
+            // Architecture Reference Manual.
+            const DEVICE_INTERRUPTS_OFFSET: u16 = 16;
+            use std::convert::TryFrom;
+            let irqn = VectActive::from(
+                u8::try_from(func() + DEVICE_INTERRUPTS_OFFSET).expect("IRQn > u8::MAX"),
+            )
+            .expect("Invalid/reserved IRQn");
+
+            Ok((b.to_string(), irqn))
+        })
+        .collect();
+    Ok(binds?.iter().cloned().collect())
+}
+
+/// Contains all metadata for a single trace.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct TraceMetadata {
+    /// Name of the RTIC application that was/is traced.
+    pub program_name: String,
+
+    /// Lookup maps for data received over ITM to RTIC application idents.
+    maps: TraceLookupMaps,
+
+    /// Timestamp of target reset, after which tracing begins.
+    ///
+    /// Note: this timestamp is sampled host-side and is approximate.
+    reset_timestamp: chrono::DateTime<Local>,
+
+    /// Frequency of the target TPIU clock. Used to generate absolute
+    /// timestamps. Set via `tpiu_freq` in
+    /// `[{package,workspace}.metadata.rtic-scope]` from `Cargo.toml` or
+    /// overridden via the `--tpiu-freq` trace option.
+    tpiu_freq: u32,
+
+    /// Optional comment of this particular trace.
+    pub comment: Option<String>,
+}
+
+impl TraceMetadata {
+    pub fn from(
+        program_name: String,
+        maps: TraceLookupMaps,
+        reset_timestamp: chrono::DateTime<Local>,
+        tpiu_freq: u32,
+        comment: Option<String>,
+    ) -> Self {
+        Self {
+            program_name,
+            maps,
+            reset_timestamp,
+            tpiu_freq,
+            comment,
+        }
+    }
+
+    pub fn hardware_tasks_len(&self) -> usize {
+        self.maps.hardware.0.len()
+    }
+
+    pub fn software_tasks_len(&self) -> usize {
+        self.maps.software.map.len()
+    }
+
+    pub fn build_event_chunk(
+        &self,
+        TimestampedTracePackets {
+            timestamp,
+            packets,
+            malformed_packets,
+            packets_consumed: _,
+        }: TimestampedTracePackets,
+    ) -> EventChunk {
+        let timestamp = {
+            let itm_decode::Timestamp {
+                base,
+                delta,
+                data_relation,
+                diverged,
+            } = timestamp;
+            let seconds_since = (base.unwrap_or(0) + delta.expect("Timestamp::delta == None"))
+                as f64
+                / self.tpiu_freq as f64;
+            let since = chrono::Duration::nanoseconds((seconds_since * 1e9).round() as i64);
+
+            api::Timestamp {
+                ts: self.reset_timestamp + since,
+                data_relation,
+                diverged,
+            }
+        };
+
+        let mut events = vec![];
+        for packet in packets.iter() {
+            match packet {
+                TracePacket::Sync => (), // noop: only used for byte alignment; contains no data
+                TracePacket::Overflow => {
+                    events.push(EventType::Overflow);
+                }
+                TracePacket::ExceptionTrace { exception, action } => events.push(EventType::Task {
+                    name: match self.maps.resolve_hardware_task(exception) {
+                        Ok(Some(name)) => name,
+                        Ok(None) => {
+                            events.push(EventType::Unknown(packet.clone()));
+                            continue;
+                        },
+                        Err(e) => {
+                            events.push(EventType::Unmappable(packet.clone(), e.to_string()));
+                            continue;
+                        }
+                    },
+                    action: match action {
+                        ExceptionAction::Entered => TaskAction::Entered,
+                        ExceptionAction::Exited => TaskAction::Exited,
+                        ExceptionAction::Returned => TaskAction::Returned,
+                    },
+                }),
+                TracePacket::DataTraceValue {
+                    comparator,
+                    access_type,
+                    value,
+                } if *access_type == MemoryAccessType::Write => {
+                    events.push(match self.maps.resolve_software_task(comparator, value) {
+                        Ok(Some(task_event)) => task_event,
+                        Ok(None) => EventType::Unknown(packet.clone()), // not a software task DWT comparator
+                        Err(e) => EventType::Unmappable(packet.clone(), e.to_string()),
+                    });
+                }
+                _ => events.push(EventType::Unknown(packet.clone())),
             }
         }
 
-        // Build the adhoc library, load it, and resolve all exception idents
-        let artifact = self.cargo.build(
-            &target_dir,
-            // Host target triple need not be specified when CARGO is set.
-            None,
-            "cdylib",
-        )?;
-        let lib = unsafe {
-            libloading::Library::new(artifact.filenames.first().unwrap())
-                .map_err(RecoveryError::LibLoadFail)?
-        };
-        let binds: Result<Vec<(proc_macro2::Ident, HwExceptionNumber)>, RecoveryError> = binds
-            .iter()
-            .map(|b| {
-                let func: libloading::Symbol<extern "C" fn() -> HwExceptionNumber> = unsafe {
-                    lib.get(format!("{}{}", ADHOC_FUNC_PREFIX, b).as_bytes())
-                        .map_err(RecoveryError::LibLookupFail)?
-                };
-                Ok((b.clone(), func()))
-            })
-            .collect();
-        Ok(binds?.iter().cloned().collect())
+        // map malformed packets
+        events.append(
+            &mut malformed_packets
+                .iter()
+                .map(|m| EventType::Invalid(m.to_owned()))
+                .collect(),
+        );
+
+        EventChunk { timestamp, events }
     }
 }

--- a/cargo-rtic-scope/src/recovery.rs
+++ b/cargo-rtic-scope/src/recovery.rs
@@ -172,7 +172,9 @@ impl TraceLookupMaps {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 struct SoftwareMap {
     pub task_dispatchers: HashSet<VectActive>,
+    #[serde(with = "vectorize")]
     pub comparators: HashMap<usize, TaskAction>,
+    #[serde(with = "vectorize")]
     pub map: HashMap<usize, Vec<String>>,
 }
 impl SoftwareMap {
@@ -300,7 +302,7 @@ impl SoftwareMap {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-struct HardwareMap(HashMap<VectActive, Vec<String>>);
+struct HardwareMap(#[serde(with = "vectorize")] HashMap<VectActive, Vec<String>>);
 impl HardwareMap {
     pub fn from(
         app: &rtic_syntax::ast::App,

--- a/cargo-rtic-scope/src/recovery.rs
+++ b/cargo-rtic-scope/src/recovery.rs
@@ -2,7 +2,7 @@ use crate::build::{self, CargoWrapper};
 use crate::diag;
 use crate::manifest::ManifestProperties;
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 
@@ -172,8 +172,8 @@ impl TraceLookupMaps {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 struct SoftwareMap {
     pub task_dispatchers: HashSet<VectActive>,
-    pub comparators: BTreeMap<usize, TaskAction>,
-    pub map: BTreeMap<usize, Vec<String>>,
+    pub comparators: HashMap<usize, TaskAction>,
+    pub map: HashMap<usize, Vec<String>>,
 }
 impl SoftwareMap {
     pub fn from(
@@ -210,7 +210,7 @@ impl SoftwareMap {
         })
     }
 
-    fn parse_ast(app: TokenStream) -> BTreeMap<usize, Vec<String>> {
+    fn parse_ast(app: TokenStream) -> HashMap<usize, Vec<String>> {
         struct TaskIDGenerator(usize);
         impl TaskIDGenerator {
             pub fn new() -> Self {
@@ -228,13 +228,13 @@ impl SoftwareMap {
 
         let app = syn::parse2::<syn::Item>(app).unwrap();
         let mut ctx: Vec<syn::Ident> = vec![];
-        let mut assocs = BTreeMap::<usize, Vec<String>>::new();
+        let mut assocs = HashMap::<usize, Vec<String>>::new();
         let mut id_gen = TaskIDGenerator::new();
 
         fn traverse_item(
             item: &syn::Item,
             ctx: &mut Vec<syn::Ident>,
-            assocs: &mut BTreeMap<usize, Vec<String>>,
+            assocs: &mut HashMap<usize, Vec<String>>,
             id_gen: &mut TaskIDGenerator,
         ) {
             match item {
@@ -393,7 +393,7 @@ fn resolve_int_nrs(
     cargo: &CargoWrapper,
     pacp: &ManifestProperties,
     binds: Vec<String>,
-) -> Result<BTreeMap<String, VectActive>, RecoveryError> {
+) -> Result<HashMap<String, VectActive>, RecoveryError> {
     const ADHOC_FUNC_PREFIX: &str = "rtic_scope_func_";
 
     // Extract adhoc source to a temporary directory and apply adhoc

--- a/cargo-rtic-scope/src/recovery.rs
+++ b/cargo-rtic-scope/src/recovery.rs
@@ -135,8 +135,8 @@ impl TraceLookupMaps {
         Ok(Some(
             self.hardware
                 .0
-                .get(&veca)
-                .ok_or(RecoveryError::MissingHardwareMapping(veca.to_owned()))?
+                .get(veca)
+                .ok_or_else(|| RecoveryError::MissingHardwareMapping(veca.to_owned()))?
                 .join("::"),
         ))
     }
@@ -144,7 +144,7 @@ impl TraceLookupMaps {
     pub fn resolve_software_task(
         &self,
         comp: &u8,
-        value: &Vec<u8>,
+        value: &[u8],
     ) -> Result<Option<EventType>, RecoveryError> {
         if let Some(action) = self.software.comparators.get(&(*comp as usize)) {
             if value.iter().filter(|&b| *b > 0).count() > 1 || value.is_empty() {
@@ -159,12 +159,12 @@ impl TraceLookupMaps {
                 .ok_or(RecoveryError::MissingSoftwareMapping(value))?
                 .join("::");
 
-            return Ok(Some(EventType::Task {
+            Ok(Some(EventType::Task {
                 name,
                 action: action.to_owned(),
-            }));
+            }))
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
 }
@@ -389,7 +389,7 @@ impl HardwareMap {
     }
 }
 
-fn resolve_int_nrs<'a>(
+fn resolve_int_nrs(
     cargo: &CargoWrapper,
     pacp: &ManifestProperties,
     binds: Vec<String>,
@@ -586,7 +586,7 @@ impl TraceMetadata {
                         Ok(None) => {
                             events.push(EventType::Unknown(packet.clone()));
                             continue;
-                        },
+                        }
                         Err(e) => {
                             events.push(EventType::Unmappable(packet.clone(), e.to_string()));
                             continue;

--- a/cargo-rtic-scope/src/sinks/file.rs
+++ b/cargo-rtic-scope/src/sinks/file.rs
@@ -1,5 +1,4 @@
-use crate::manifest::ManifestProperties;
-use crate::recovery::{Metadata, TaskResolveMaps};
+use crate::recovery::{TraceLookupMaps, TraceMetadata};
 use crate::sinks::{Sink, SinkError};
 use crate::TraceData;
 use std::fs;
@@ -85,11 +84,10 @@ impl FileSink {
     pub fn init<F>(
         &mut self,
         program_name: String,
-        maps: TaskResolveMaps,
-        manip: ManifestProperties,
+        maps: TraceLookupMaps,
         comment: Option<String>,
         reset_fun: F,
-    ) -> Result<Metadata, SinkError>
+    ) -> Result<TraceMetadata, SinkError>
     where
         F: FnOnce() -> Result<u32, crate::sources::SourceError>,
     {
@@ -99,7 +97,7 @@ impl FileSink {
         // Create a trace file header with metadata (maps, reset
         // timestamp, trace clock frequency). Any bytes after this
         // sequence refers to trace packets.
-        let metadata = Metadata::new(program_name, maps, manip, ts, freq, comment);
+        let metadata = TraceMetadata::from(program_name, maps, ts, freq, comment);
         {
             let json = serde_json::to_string(&metadata)?;
             self.file.write_all(json.as_bytes())

--- a/cargo-rtic-scope/src/sinks/file.rs
+++ b/cargo-rtic-scope/src/sinks/file.rs
@@ -4,7 +4,7 @@ use crate::TraceData;
 use std::fs;
 
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use cargo_metadata::Artifact;
 use chrono::prelude::*;
@@ -21,7 +21,7 @@ pub struct FileSink {
 impl FileSink {
     pub fn generate_trace_file(
         artifact: &Artifact,
-        trace_dir: &PathBuf,
+        trace_dir: &Path,
         remove_prev_traces: bool,
     ) -> Result<Self, SinkError> {
         if remove_prev_traces {

--- a/cargo-rtic-scope/src/sources/file.rs
+++ b/cargo-rtic-scope/src/sources/file.rs
@@ -1,4 +1,4 @@
-use crate::recovery::Metadata;
+use crate::recovery::TraceMetadata;
 use crate::sources::{BufferStatus, Source, SourceError};
 use crate::TraceData;
 
@@ -8,7 +8,7 @@ use std::io::BufReader;
 /// Something data is deserialized from. Always a file.
 pub struct FileSource {
     reader: BufReader<fs::File>,
-    metadata: Metadata,
+    metadata: TraceMetadata,
 }
 
 impl FileSource {
@@ -16,7 +16,7 @@ impl FileSource {
         let mut reader = BufReader::new(fd);
         let metadata = {
             let mut stream =
-                serde_json::Deserializer::from_reader(&mut reader).into_iter::<Metadata>();
+                serde_json::Deserializer::from_reader(&mut reader).into_iter::<TraceMetadata>();
             if let Some(Ok(metadata)) = stream.next() {
                 metadata
             } else {
@@ -29,7 +29,7 @@ impl FileSource {
         Ok(Self { reader, metadata })
     }
 
-    pub fn metadata(&self) -> Metadata {
+    pub fn metadata(&self) -> TraceMetadata {
         self.metadata.clone()
     }
 }

--- a/cargo-rtic-scope/src/sources/mod.rs
+++ b/cargo-rtic-scope/src/sources/mod.rs
@@ -17,6 +17,7 @@ pub enum BufferStatus {
     NotApplicable,
 }
 
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Error)]
 pub enum SourceError {
     #[error("Failed to setup source: {0}")]

--- a/cargo-rtic-scope/src/sources/tty.rs
+++ b/cargo-rtic-scope/src/sources/tty.rs
@@ -39,7 +39,7 @@ mod ioctl {
 ///
 /// TODO ensure POSIX compliance, see termios(3)
 /// TODO We are currently using line disciple 0. Is that correct?
-pub fn configure(device: &String) -> Result<fs::File, SourceError> {
+pub fn configure(device: &str) -> Result<fs::File, SourceError> {
     let file = fs::OpenOptions::new()
         .read(true)
         .open(&device)


### PR DESCRIPTION
To declare a software task in RTIC a software task dispatcher exception must be configured. This exception will be entered when a task is scheduled to run, and exit when relevant tasks has finished executing. An exception trace packet will be omitted, but this packet is not presently mapped. `cargo-rtic-scope` should intercept it and handle it in some way.