### PR TITLE
Buffer packets from target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "clap",
  "colored",
  "cortex-m 0.7.3",
+ "crossbeam-channel",
  "crossterm",
  "ctrlc",
  "futures",
@@ -377,6 +378,26 @@ dependencies = [
  "cortex-m 0.7.3",
  "rtic-trace-macros",
  "stm32f4",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
 dependencies = [
- "gimli",
+ "gimli 0.25.0",
 ]
 
 [[package]]
@@ -632,6 +632,12 @@ name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
@@ -812,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "jep106"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "939876d20519325db0883757e29e9858ee02919d0f03e43c74f69296caa314f4"
+checksum = "e80f965a2a659a7a4d9cdb9821a869d6e33c10f3e094e8f7d01648063c425953"
 dependencies = [
  "serde",
 ]
@@ -1141,8 +1147,8 @@ checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "probe-rs"
-version = "0.11.0"
-source = "git+https://github.com/probe-rs/probe-rs.git#d2b13bf47507c85fbccdb170a4c3bcac86985613"
+version = "0.12.0"
+source = "git+https://github.com/probe-rs/probe-rs.git#bf7d826f2b0167b8a97f3623698fb8d018031ce3"
 dependencies = [
  "anyhow",
  "base64",
@@ -1150,7 +1156,7 @@ dependencies = [
  "bitfield",
  "bitvec",
  "enum-primitive-derive",
- "gimli",
+ "gimli 0.26.1",
  "hidapi",
  "ihex",
  "jaylink",
@@ -1172,8 +1178,8 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-cli-util"
-version = "0.11.0"
-source = "git+https://github.com/probe-rs/probe-rs.git#d2b13bf47507c85fbccdb170a4c3bcac86985613"
+version = "0.12.0"
+source = "git+https://github.com/probe-rs/probe-rs.git#bf7d826f2b0167b8a97f3623698fb8d018031ce3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1194,8 +1200,8 @@ dependencies = [
 
 [[package]]
 name = "probe-rs-target"
-version = "0.11.0"
-source = "git+https://github.com/probe-rs/probe-rs.git#d2b13bf47507c85fbccdb170a4c3bcac86985613"
+version = "0.12.0"
+source = "git+https://github.com/probe-rs/probe-rs.git#bf7d826f2b0167b8a97f3623698fb8d018031ce3"
 dependencies = [
  "base64",
  "jep106",
@@ -1526,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "simplelog"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85d04ae642154220ef00ee82c36fb07853c10a4f2a0ca6719f9991211d2eb959"
+checksum = "8baa24de25f3092d9697c76f94cf09f67fca13db2ea11ce80c2f055c1aaf0795"
 dependencies = [
  "chrono",
  "log",

--- a/cargo-rtic-scope/Cargo.toml
+++ b/cargo-rtic-scope/Cargo.toml
@@ -35,11 +35,11 @@ cortex-m = { version = "0.7", default-features = false, features = ["serde", "st
 indexmap = { version = "1.7", features = [ "serde-1" ] }
 
 [dependencies.probe-rs]
-version = "0.11"
+version = "0.12"
 git = "https://github.com/probe-rs/probe-rs.git"
 
 [dependencies.probe-rs-cli-util]
-version = "0.11"
+version = "0.12"
 git = "https://github.com/probe-rs/probe-rs.git"
 
 [dependencies.anyhow]

--- a/cargo-rtic-scope/Cargo.toml
+++ b/cargo-rtic-scope/Cargo.toml
@@ -33,6 +33,7 @@ crossterm = "0.20"
 futures = "0.3"
 cortex-m = { version = "0.7", default-features = false, features = ["serde", "std-map"] }
 indexmap = { version = "1.7", features = [ "serde-1" ] }
+crossbeam-channel = "0.5.1"
 
 [dependencies.probe-rs]
 version = "0.12"

--- a/cargo-rtic-scope/src/main.rs
+++ b/cargo-rtic-scope/src/main.rs
@@ -236,9 +236,9 @@ async fn main_try() -> Result<(), RTICScopeError> {
 
     // Build RTIC application to be traced, and create a wrapper around
     // cargo, reusing the target directory of the application.
-    log::status("Building", "RTIC target application...".to_string());
     #[allow(clippy::needless_question_mark)]
     let cart = async {
+        log::status("Building", "RTIC target application...".to_string());
         Ok(CargoWrapper::new(
             &env::current_dir().map_err(CargoError::CurrentDirError)?,
             {

--- a/cargo-rtic-scope/src/main.rs
+++ b/cargo-rtic-scope/src/main.rs
@@ -592,6 +592,7 @@ async fn trace(
         &elf.clone().into_std_path_buf(),
         &opts.flash_options,
         flashloader,
+        true, // do_chip_erase
     )?;
 
     let mut trace_source: Box<dyn sources::Source> = if let Some(dev) = &opts.serial {

--- a/cargo-rtic-scope/src/sources/mod.rs
+++ b/cargo-rtic-scope/src/sources/mod.rs
@@ -38,7 +38,7 @@ pub enum SourceError {
 
 impl diag::DiagnosableError for SourceError {}
 
-pub trait Source: Iterator<Item = Result<TraceData, SourceError>> {
+pub trait Source: Iterator<Item = Result<TraceData, SourceError>> + std::marker::Send {
     fn reset_target(&mut self, _reset_halt: bool) -> Result<(), SourceError> {
         Ok(())
     }


### PR DESCRIPTION
This PR implements packet buffering by help of a separate thread and an
unbounded channel. The separate thread is used to continuously can
`source.next()` so that we clear the source buffer as quickly as possible.
The crossbeam-channel API does not enable us to query the number of
buffered packets, but I suppose this is not that important. Closes #73.

The halt signal now also uses channel. This channel is a bounded channel
of zero size, effectively making it a randezvous channel: the SIGINT
handler will not exit until the SIGINT has been received in `run_loop`.
This seems to close #70: we no longer bog down a core to check the flag.
The performance drain now seems to be `source.next()`.

As a side effect of using channels instead of `futures::stream`, we can
also close #69.