### PR TITLE
recovery: parse for `#[rtic::app]` instead of `#[app]`

### DIFF
--- a/.ci/expected/out/invalid-arg.run
+++ b/.ci/expected/out/invalid-arg.run
@@ -1,3 +1,2 @@
 Error Failed to find arguments to RTIC application
-Hint RTIC Scope expects an RTIC application declaration on the form `#[app(...)] mod app { ... }` where the first `...` is the application arguments.
-Hint Change #[rtic::app(...)] to #[app(...)] via `use rtic::app;`.
+Hint RTIC Scope expects an RTIC application declaration on the form `#[rtic::app(...)] mod app { ... }` where the first `...` is the application arguments.

--- a/.ci/expected/src/bin/general.rs
+++ b/.ci/expected/src/bin/general.rs
@@ -4,9 +4,9 @@
 #![no_std]
 
 use panic_semihosting as _;
-use rtic::app;
+use rtic;
 
-#[app(device = stm32f4::stm32f401, dispatchers = [EXTI0, EXTI1])]
+#[rtic::app(device = stm32f4::stm32f401, dispatchers = [EXTI0, EXTI1])]
 mod app {
     use cortex_m_rtic_trace::{trace};
 

--- a/.ci/expected/src/bin/invalid-arg.rs
+++ b/.ci/expected/src/bin/invalid-arg.rs
@@ -4,9 +4,9 @@
 #![no_std]
 
 use panic_semihosting as _;
-// use rtic::app;
+use rtic::app;
 
-#[rtic::app(device = stm32f4::stm32f401, dispatchers = [EXTI0, EXTI1])]
+#[app(device = stm32f4::stm32f401, dispatchers = [EXTI0, EXTI1])]
 mod app {
     use cortex_m_rtic_trace::{trace};
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,21 @@ jobs:
           command: fmt
           args: -- --check
 
+  test:
+    name: test
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install libusb, libudev # for hidapi in probe-rs
+        run: |
+          sudo apt update
+          sudo apt install -y libusb-1.0-0-dev libudev-dev
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all
+
   clippy:
     name: clippy
     runs-on: ubuntu-20.04

--- a/cortex-m-rtic-trace/src/lib.rs
+++ b/cortex-m-rtic-trace/src/lib.rs
@@ -6,7 +6,7 @@
 //! - `tracing`: which offers setup functions that configures related
 //!   peripherals for RTIC task tracing, and a `#[trace]` macro for
 //!   software tasks. Example usage (TODO update):
-//!   ```
+//!   ```ignore
 //!   #[app(device = stm32f4::stm32f401, peripherals = true, dispatchers = [EXTI1])]
 //!   mod app {
 //!       use rtic_trace::{self, tracing::trace};

--- a/examples/src/bin/blinky.rs
+++ b/examples/src/bin/blinky.rs
@@ -2,9 +2,9 @@
 #![no_main]
 
 use panic_halt as _; // panic handler
-use rtic::app;
+use rtic;
 
-#[app(device = stm32f4::stm32f401, peripherals = true, dispatchers = [EXTI0])]
+#[rtic::app(device = stm32f4::stm32f401, peripherals = true, dispatchers = [EXTI0])]
 mod app {
     use cortex_m::peripheral::syst::SystClkSource;
     use cortex_m_rtic_trace::{self, trace};

--- a/examples/src/bin/software.rs
+++ b/examples/src/bin/software.rs
@@ -4,9 +4,9 @@
 #![no_std]
 
 use panic_semihosting as _;
-use rtic::app;
+use rtic;
 
-#[app(device = stm32f4::stm32f401, dispatchers = [EXTI0, EXTI1])]
+#[rtic::app(device = stm32f4::stm32f401, dispatchers = [EXTI0, EXTI1])]
 mod app {
     use cortex_m_rtic_trace::{setup, trace};
 


### PR DESCRIPTION
I believe it's not that often one imports the `app`-macro itself, but
uses it via `rtic::app`. This should remove a papercut for new users.

Closes #54.