### PR TITLE
sources/tty: apply user-supplied baud rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `/docs/`, a submodule that contains the overarching documentation of RTIC Scope, which is rendered at [the organization profile](https://github.com/rtic-scope).
 
+### Changed
+- On `--serial /path/to/dev`, `dev` will no longer unconditionally configure for 115200 B/s; the baud rate specified with `tpiu_baud` in the `[package.metadata.rtic-scope]` block in `Cargo.toml` will instead be applied.
+  For example, `tpiu_baud = 9600` will configure `dev` for 9600 B/s.
+  Valid baud rates are listed in [`nix::sys::termios::BaudRate`](https://docs.rs/nix/0.23.1/nix/sys/termios/enum.BaudRate.html), with the exception of `B0`.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [0.3.0] - 2022-01-05
 Initial release tracked by this changelog.
 

--- a/cargo-rtic-scope/src/main.rs
+++ b/cargo-rtic-scope/src/main.rs
@@ -708,7 +708,8 @@ async fn trace(
 
     let trace_source: Box<dyn sources::Source> = if let Some(dev) = &opts.serial {
         Box::new(sources::TTYSource::new(
-            sources::tty::configure(dev).with_context(|| format!("Failed to configure {}", dev))?,
+            sources::tty::configure(dev, manip.tpiu_baud)
+                .with_context(|| format!("Failed to configure {}", dev))?,
             &manip,
         ))
     } else {


### PR DESCRIPTION
Before this commit, dev in

    --serial /path/to/dev

would always be configured for 115200 B/s, even if the user supplied
another rate in the manifest via tpiu_baud, e.g. 9600 B/s. A baud rate
that converts to a nix::sys::termios::BaudRate that isn't B0 must be
supplied.

Ideally we should CI this, but that requires a CI refactor so that
--serial can be specified. This is non-trivial, and we better handle #77
first.