### PR TITLE
trace: dont notice target mutation on --dont-touch-target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- No longer prints "Target reset and flashed." on `trace --dont-touch-target`.
 
 ### Security
 

--- a/cargo-rtic-scope/src/main.rs
+++ b/cargo-rtic-scope/src/main.rs
@@ -746,7 +746,12 @@ async fn trace(
     log::status(
         "Recovered",
         format!(
-            "{ntotal} task(s) from {prog}: {nhard} hard, {nsoft} soft. Target reset and flashed.",
+            "{ntotal} task(s) from {prog}: {nhard} hard, {nsoft} soft.{}",
+            if !opts.dont_touch_target {
+                "Target reset and flashed."
+            } else {
+                ""
+            },
             ntotal = metadata.hardware_tasks_len() + metadata.software_tasks_len(),
             prog = metadata.program_name,
             nhard = metadata.hardware_tasks_len(),


### PR DESCRIPTION
The target is not touched, so the notice was incorrectly printed.