### PR TITLE
`run_loop`: improve overflow warning message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On `--serial /path/to/dev`, `dev` will no longer unconditionally configure for 115200 B/s; the baud rate specified with `tpiu_baud` in the `[package.metadata.rtic-scope]` block in `Cargo.toml` will instead be applied.
   For example, `tpiu_baud = 9600` will configure `dev` for 9600 B/s.
   Valid baud rates are listed in [`nix::sys::termios::BaudRate`](https://docs.rs/nix/0.23.1/nix/sys/termios/enum.BaudRate.html), with the exception of `B0`.
+- Improved the warning message when an overflow packet is decoded.
+  It will now detail that non-timestamp packets have been dropped and/or that the local timestamp counter wrapped which means that timestamps from then on are *potentially* diverged.
 
 ### Deprecated
 

--- a/cargo-rtic-scope/src/main.rs
+++ b/cargo-rtic-scope/src/main.rs
@@ -538,7 +538,7 @@ where
                     stats.malformed += 1;
                     log::warn(format!("malformed packet: {}: {:?}", malformed, malformed));
                 },
-                api::EventType::Overflow => log::warn("Overflow detected! Packets may have been dropped and timestamps will be diverged until the next global timestamp".to_string()),
+                api::EventType::Overflow => log::warn("Overflow detected! Packets may have been dropped and/or timestamps will potentially be diverged until the next global timestamp.".to_string()),
                 _ => (),
             }
         }


### PR DESCRIPTION
Previous message noted that timestamps have unconditionally diverged
which may not be the case: we simply can't be sure. The new message also
notes that timestamps *and/or* data packets have been dropped.