### PR TITLE
Bump `cortex-m`, improve order of operations in `configure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore enters and exits relating to the `ThreadMode` interrupt: RTIC always executes tasks in handler mode and then returns to `ThreadMode` on `cortex_m::asm::wfi()`.
 - Bumped `itm` to v0.7.0 with its `"serial"` feature; the latter used to configure a TTY source.
 - Emit a warning if a DWT watch address used for software task tracing is read. Such an address should only ever be written to. This error would indicate that something has gone very wrong.
+- Crate documentation for `rtic-scope-frontend-dummy`, `cortex-m-rtic-trace`, and `rtic-scope-api` which is now the same as `README.md` used for the organization documentation but with a small header summarizing the crate.
+- Bumped `cortex-m`, ensuring additional target support verification during `cortex_m_rtic_trace::configure`.
 
 ### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,7 @@ dependencies = [
 [[package]]
 name = "cortex-m"
 version = "0.7.4"
-source = "git+https://github.com/rtic-scope/cortex-m?branch=rtic-scope#987c900added2aad32d906a615ed23c83f46acd0"
+source = "git+https://github.com/rtic-scope/cortex-m?branch=rtic-scope#83e0b768f90b62d03abcae4b347003772225edfa"
 dependencies = [
  "bare-metal",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ members = [
 
 [patch.crates-io]
 include_dir = { version = "0.6.3-alpha.0", git = "https://github.com/tmplt/include_dir.git", branch = "feat/extract-overwrite" }
+cortex-m = { version = "0.7", git = "https://github.com/rtic-scope/cortex-m", branch = "rtic-scope" }

--- a/cargo-rtic-scope/Cargo.toml
+++ b/cargo-rtic-scope/Cargo.toml
@@ -31,7 +31,7 @@ include_dir = "0.6.3-alpha.0"
 libloading = "0.7"
 rtic-syntax = "1.0.0"
 tempfile = "3"
-cortex-m = { version = "0.7", git = "https://github.com/rtic-scope/cortex-m", branch = "rtic-scope", default-features = false, features = ["serde", "std"]}
+cortex-m = { version = "0.7", default-features = false, features = ["serde", "std"]}
 
 # Probe support
 probe-rs = { version = "0.12", git = "https://github.com/rtic-scope/probe-rs.git", branch = "feat/swo-read" }

--- a/cortex-m-rtic-trace/Cargo.toml
+++ b/cortex-m-rtic-trace/Cargo.toml
@@ -9,5 +9,5 @@ homepage = "https://github.com/rtic-scope/cortex-m-rtic-trace"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-cortex-m = { version = "0.7.3", git = "https://github.com/rtic-scope/cortex-m.git", branch = "rtic-scope" }
+cortex-m = "0.7.3"
 rtic-trace-macros = { path = "macros", version = "0.0.0" }


### PR DESCRIPTION
This PR contains https://github.com/rust-embedded/cortex-m/pull/383 which verifies more target support during ITM configuration.