### PR TITLE
Bump `itm`, improving upon the `api::Timestamp` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- Bump `itm` which improves the denotation of quality in the downstream `api::Timestamp`: a previous `api::Timestamp { offset: 1, data_relation: TimestampDataRelation::Sync }` is now represented as `api::Timestamp::Sync(1)`.
 ### Deprecated
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,14 +33,8 @@ The largest change is that on `trace --serial`, the given device is not uncondit
 - Bumped `cortex-m`, ensuring additional target support verification during `cortex_m_rtic_trace::configure`.
 - Messages from frontends are now prefixed by a cyan "Frontend" instead of a red "Error".
 
-### Deprecated
-
-### Removed
-
 ### Fixed
 - No longer prints "Target reset and flashed." or "preparing target" on `trace --dont-touch-target`.
-
-### Security
 
 ## [0.3.0] - 2022-01-05
 Initial release tracked by this changelog.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ dependencies = [
 [[package]]
 name = "itm"
 version = "0.7.0"
-source = "git+https://github.com/rtic-scope/itm.git#fa8d153e8461b4cde6dcc352f2107775c349ed4a"
+source = "git+https://github.com/rtic-scope/itm.git#d91f4ed6dfafd1fc461be1956ab5d667a9f9e5ea"
 dependencies = [
  "bitmatch",
  "bitvec",

--- a/contrib/flake.lock
+++ b/contrib/flake.lock
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1641177598,
-        "narHash": "sha256-ixQ72QmhIfb7bAzvLUn6GtjpoMA/N3V1PBwjZQQyc1k=",
+        "lastModified": 1642838864,
+        "narHash": "sha256-pHnhm3HWwtvtOK7NdNHwERih3PgNlacrfeDwachIG8E=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d93e905bc0d36508590b6ec0e2e6e92d2cf8289a",
+        "rev": "9fb49daf1bbe1d91e6c837706c481f9ebb3d8097",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
See changelog.