### PR TITLE
rtic-trace: ptr::write_volatile watch variables instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+- `cortex-m-rtic-trace::trace`: write watch variables using `ptr::volatile_write` instead, signaling that the write should not be optimized out.
 ### Deprecated
 ### Security
 

--- a/cortex-m-rtic-trace/src/lib.rs
+++ b/cortex-m-rtic-trace/src/lib.rs
@@ -151,7 +151,7 @@ pub fn configure(
 #[inline]
 pub fn __write_enter_id(id: u8) {
     unsafe {
-        WATCH_VARIABLE_ENTER.id = id;
+        core::ptr::write_volatile(&mut WATCH_VARIABLE_ENTER.id, id);
     }
 }
 
@@ -161,6 +161,6 @@ pub fn __write_enter_id(id: u8) {
 #[inline]
 pub fn __write_exit_id(id: u8) {
     unsafe {
-        WATCH_VARIABLE_EXIT.id = id;
+        core::ptr::write_volatile(&mut WATCH_VARIABLE_EXIT.id, id);
     }
 }


### PR DESCRIPTION
The compiler is not aware of the relationship between the watch
variables and the DWT comparators that monitors the variables. Using
ptr::volatile_write should convince the compiler not to optimize the
write out.