### PR TITLE
Fix dummy timestamp unit and add header on replay --list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 - `cortex-m-rtic-trace::trace`: write watch variables using `ptr::volatile_write` instead, signaling that the write should not be optimized out.
+- `rtic-scope-frontend-dummy`: correctly report absolute timestamps as nanoseconds, not microseconds.
 ### Deprecated
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `cargo rtic-scope replay --list`: print out a non-exhaustive header describing the index and trace file name, but not the comment (#140).
 ### Changed
 - `cortex-m-rtic-trace::trace`: write watch variables using `ptr::volatile_write` instead, signaling that the write should not be optimized out.
 - `rtic-scope-frontend-dummy`: correctly report absolute timestamps as nanoseconds, not microseconds.
+- `cargo rtic-scope replay --list`: only print the trace comment if it exists (previously printed "None").
 ### Deprecated
 ### Security
 

--- a/cargo-rtic-scope/src/main.rs
+++ b/cargo-rtic-scope/src/main.rs
@@ -809,11 +809,17 @@ async fn replay(
                         .into(),
                 ),
             )?;
+            println!("index\ttrace file");
             for (i, trace) in traces.enumerate() {
                 let metadata =
                     sources::FileSource::new(fs::OpenOptions::new().read(true).open(&trace)?)?
                         .metadata();
-                println!("{}\t{}\t{:?}", i, trace.display(), metadata.comment);
+                println!(
+                    "{}\t{}\t{}",
+                    i,
+                    trace.display(),
+                    metadata.comment.unwrap_or_else(|| "".to_string())
+                );
             }
 
             Ok(None)

--- a/rtic-scope-frontend-dummy/src/main.rs
+++ b/rtic-scope-frontend-dummy/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
             | api::Timestamp::UnknownAssocEventDelay { prev: _, curr } => ("bad!", curr.as_nanos()),
         };
         let diff = nanos - prev_nanos;
-        eprintln!("@{nanos} µs (+{diff} ns) [{quality}]: {events:?}");
+        eprintln!("@{nanos} ns (+{diff} ns) [{quality}]: {events:?}");
         prev_nanos = nanos;
     }
 


### PR DESCRIPTION
Before this PR nanosecond timestamps where incorrectly reported as microseconds. This PR also adds a non-exhaustive header to the printout of `replay --list` for documentation purposes.