### PR TITLE
rtic-trace: wrap task code in closure on #[trace] instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cortex-m-rtic-trace::trace`: write watch variables using `ptr::volatile_write` instead, signaling that the write should not be optimized out.
 - `rtic-scope-frontend-dummy`: correctly report absolute timestamps as nanoseconds, not microseconds.
 - `cargo rtic-scope replay --list`: only print the trace comment if it exists (previously printed "None").
+### Fixed
+- `cortex-m-rtic-trace::trace`: correctly handle tasks/functions that exit prematurely or return a value.
+
 ### Deprecated
 ### Security
 


### PR DESCRIPTION
Before this commit, traced tasks/functions were not allowed to
prematurely exit, nor return anything.

Closes #63.