### PR TITLE
recovery: build libadhoc without default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cargo rtic-scope replay --list`: only print the trace comment if it exists (previously printed "None").
 ### Fixed
 - `/contrib`: update lock file; `cargo-rtic-scope` now builds again inside a `nix develop` shell.
+- Builds of PACs with default features like `device` or `rt` during recovery stage, which previously resulted in fatal linker errors.
 ### Deprecated
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `cortex-m-rtic-trace::trace`: write watch variables using `ptr::volatile_write` instead, signaling that the write should not be optimized out.
 - `rtic-scope-frontend-dummy`: correctly report absolute timestamps as nanoseconds, not microseconds.
 - `cargo rtic-scope replay --list`: only print the trace comment if it exists (previously printed "None").
+### Fixed
+- `/contrib`: update lock file; `cargo-rtic-scope` now builds again inside a `nix develop` shell.
 ### Deprecated
 ### Security
 

--- a/cargo-rtic-scope/src/recovery.rs
+++ b/cargo-rtic-scope/src/recovery.rs
@@ -432,7 +432,7 @@ fn resolve_int_nrs(
             .open(target_dir.join("Cargo.toml"))
             .map_err(RecoveryError::LibExtractFail)?;
         let dep = format!(
-            "\n{} = {{ version = \"{}\", features = [{}]}}\n",
+            "\n{} = {{ version = \"{}\", default-features = false, features = [{}]}}\n",
             pacp.pac_name,
             pacp.pac_version,
             pacp.pac_features

--- a/contrib/flake.lock
+++ b/contrib/flake.lock
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1642838864,
-        "narHash": "sha256-pHnhm3HWwtvtOK7NdNHwERih3PgNlacrfeDwachIG8E=",
+        "lastModified": 1655175026,
+        "narHash": "sha256-Ly+9jnoRtRvSOB2KfNIxP+VlqoJZ+Iz2doeItuqY29s=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9fb49daf1bbe1d91e6c837706c481f9ebb3d8097",
+        "rev": "609f28f58c849c31b6a49fa1a75a72b08962ba62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Before this commit, PACs with some default features could result in fatal liker errors.

This commit also updates `contrib/flake.lock`: `cargo-rtic-scope` now builds again inside a `nix develop` shell.